### PR TITLE
Add user service tests

### DIFF
--- a/user-service/src/test/java/com/practice/quarkus/user/application/UserServiceTest.java
+++ b/user-service/src/test/java/com/practice/quarkus/user/application/UserServiceTest.java
@@ -1,0 +1,74 @@
+package com.practice.quarkus.user.application;
+
+import com.practice.quarkus.user.domain.model.Pet;
+import com.practice.quarkus.user.domain.service.UserDomainService;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class UserServiceTest {
+
+    private static void inject(UserService service, UserDomainService domainService) throws Exception {
+        Field field = UserService.class.getDeclaredField("userDomainService");
+        field.setAccessible(true);
+        field.set(service, domainService);
+    }
+
+    @Test
+    void addPetReturnsSuccessMessage() throws Exception {
+        UserDomainService domainService = mock(UserDomainService.class);
+        UserService service = new UserService();
+        inject(service, domainService);
+
+        String result = service.addPetToUser("1", "dog", "bulldog");
+
+        verify(domainService).addPetToUser("1", "dog", "bulldog");
+        assertEquals("Pet added  to user 1", result);
+    }
+
+    @Test
+    void addPetReturnsErrorMessageOnFailure() throws Exception {
+        UserDomainService domainService = mock(UserDomainService.class);
+        doThrow(new RuntimeException("boom")).when(domainService).addPetToUser(any(), any(), any());
+        UserService service = new UserService();
+        inject(service, domainService);
+
+        String result = service.addPetToUser("2", "cat", "persian");
+
+        verify(domainService).addPetToUser("2", "cat", "persian");
+        assertTrue(result.contains("Unable to add pet to user"));
+    }
+
+    @Test
+    void listPetsReturnsFromService() throws Exception {
+        UserDomainService domainService = mock(UserDomainService.class);
+        List<Pet> pets = List.of(new Pet("Buddy", "dog", "labrador"));
+        when(domainService.petsOwnedByUser("3")).thenReturn(pets);
+        UserService service = new UserService();
+        inject(service, domainService);
+
+        List<Pet> result = service.listPets("3");
+
+        verify(domainService).petsOwnedByUser("3");
+        assertEquals(pets, result);
+    }
+
+    @Test
+    void listPetsReturnsEmptyListOnFailure() throws Exception {
+        UserDomainService domainService = mock(UserDomainService.class);
+        when(domainService.petsOwnedByUser(any())).thenThrow(new RuntimeException());
+        UserService service = new UserService();
+        inject(service, domainService);
+
+        List<Pet> result = service.listPets("4");
+
+        verify(domainService).petsOwnedByUser("4");
+        assertTrue(result.isEmpty());
+    }
+}
+

--- a/user-service/src/test/java/com/practice/quarkus/user/domain/service/UserDomainServiceIT.java
+++ b/user-service/src/test/java/com/practice/quarkus/user/domain/service/UserDomainServiceIT.java
@@ -1,0 +1,71 @@
+package com.practice.quarkus.user.domain.service;
+
+import com.practice.quarkus.user.domain.model.Pet;
+import com.practice.quarkus.user.infrastructure.repository.UserDomainRepository;
+import com.practice.quarkus.user.infrastructure.rest.api.PetServiceApiClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UserDomainServiceIT {
+
+    private static MockWebServer server;
+
+    @BeforeAll
+    static void setup() throws IOException {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    private UserDomainService createService() {
+        URI baseUri = server.url("/").uri();
+        PetServiceApiClient client = RestClientBuilder.newBuilder()
+                .baseUri(baseUri)
+                .build(PetServiceApiClient.class);
+        UserDomainRepository repo = new UserDomainRepository(client);
+        return new UserDomainService(repo, repo);
+    }
+
+    @Test
+    void petsOwnedByUserCallsRepository() throws Exception {
+        String json = "{\"petName\":\"Max\",\"petType\":\"dog\",\"breed\":\"terrier\"}";
+        server.enqueue(new MockResponse()
+                .setBody("[\"" + json + "\"]")
+                .addHeader("Content-Type", "application/json"));
+
+        UserDomainService service = createService();
+        List<Pet> pets = service.petsOwnedByUser("5");
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("/pet-service?userId=5", request.getPath());
+        assertEquals("GET", request.getMethod());
+        assertEquals(List.of(new Pet("Max", "dog", "terrier")), pets);
+    }
+
+    @Test
+    void addPetToUserCallsRepository() throws Exception {
+        server.enqueue(new MockResponse().setBody("true"));
+        UserDomainService service = createService();
+        service.addPetToUser("7", "cat", "siamese");
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("/pet-service/add-pet?userId=7&petType=cat&petBreed=siamese", request.getPath());
+        assertEquals("POST", request.getMethod());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for the REST service logic
- add an integration test exercising the domain service with HTTP

## Testing
- `./mvnw test -q`
- `./mvnw verify -DskipITs=false -q`


------
https://chatgpt.com/codex/tasks/task_e_6862750a0c4c832b9f5bd33c7633e940