### PR TITLE
Add pet-service module with Postgres database

### DIFF
--- a/pet-service/pom.xml
+++ b/pet-service/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.practice.quarkus</groupId>
+        <artifactId>code-with-quarkus</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>pet-service</artifactId>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>19</maven.compiler.source>
+        <maven.compiler.target>19</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-flyway</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/pet-service/src/main/java/com/practice/quarkus/pet/Pet.java
+++ b/pet-service/src/main/java/com/practice/quarkus/pet/Pet.java
@@ -1,0 +1,4 @@
+package com.practice.quarkus.pet;
+
+public record Pet(String petName, String petType, String breed) {
+}

--- a/pet-service/src/main/java/com/practice/quarkus/pet/PetEntity.java
+++ b/pet-service/src/main/java/com/practice/quarkus/pet/PetEntity.java
@@ -1,0 +1,19 @@
+package com.practice.quarkus.pet;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "pets")
+public class PetEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    public String ownerId;
+    public String petType;
+    public String petBreed;
+}

--- a/pet-service/src/main/java/com/practice/quarkus/pet/PetRepository.java
+++ b/pet-service/src/main/java/com/practice/quarkus/pet/PetRepository.java
@@ -1,0 +1,31 @@
+package com.practice.quarkus.pet;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import java.util.List;
+
+@ApplicationScoped
+public class PetRepository {
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Transactional
+    public void addPet(String ownerId, String type, String breed) {
+        PetEntity pet = new PetEntity();
+        pet.ownerId = ownerId;
+        pet.petType = type;
+        pet.petBreed = breed;
+        em.persist(pet);
+    }
+
+    public List<Pet> findByOwner(String ownerId) {
+        return em.createQuery("from PetEntity where ownerId = :owner", PetEntity.class)
+                .setParameter("owner", ownerId)
+                .getResultStream()
+                .map(e -> new Pet(e.petBreed, e.petType, e.petBreed))
+                .toList();
+    }
+}

--- a/pet-service/src/main/java/com/practice/quarkus/pet/PetResource.java
+++ b/pet-service/src/main/java/com/practice/quarkus/pet/PetResource.java
@@ -1,0 +1,29 @@
+package com.practice.quarkus.pet;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import java.util.List;
+
+@Path("/pet-service")
+public class PetResource {
+
+    @Inject
+    PetRepository repository;
+
+    @GET
+    public List<Pet> getPets(@QueryParam("userId") String userId) {
+        return repository.findByOwner(userId);
+    }
+
+    @POST
+    @Path("/add-pet")
+    public boolean addPet(@QueryParam("userId") String userId,
+                          @QueryParam("petType") String petType,
+                          @QueryParam("petBreed") String petBreed) {
+        repository.addPet(userId, petType, petBreed);
+        return true;
+    }
+}

--- a/pet-service/src/main/resources/application.properties
+++ b/pet-service/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/petdb
+quarkus.datasource.username=petuser
+quarkus.datasource.password=petpass
+quarkus.hibernate-orm.database.generation=validate
+quarkus.flyway.migrate-at-start=true

--- a/pet-service/src/main/resources/db/migration/V1__create_pets.sql
+++ b/pet-service/src/main/resources/db/migration/V1__create_pets.sql
@@ -1,0 +1,6 @@
+CREATE TABLE pets (
+    id SERIAL PRIMARY KEY,
+    owner_id VARCHAR(50) NOT NULL,
+    pet_type VARCHAR(50) NOT NULL,
+    pet_breed VARCHAR(50) NOT NULL
+);

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <packaging>pom</packaging>
     <modules>
         <module>user-service</module>
+        <module>pet-service</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary
- add new `pet-service` module for managing pets
- configure PostgreSQL datasource and Flyway migration
- expose REST endpoints for listing and adding pets
- include new module in the Maven build

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862875c9b78832b82a9597fdfe69d22